### PR TITLE
Support a custom "toString" function

### DIFF
--- a/fixtures/inputs.js
+++ b/fixtures/inputs.js
@@ -87,5 +87,26 @@ module.exports = {
       '| Sarah | 22    | true   |',
       '| Lee   | 23    | true   |',
     ].join(os.EOL) + os.EOL
+  },
+  coerce: {
+    input: [
+      { name: 'Bob', age: 21, isCool: false },
+      { name: 'Sarah', age: 22, isCool: true },
+      { name: 'Lee', age: 23, isCool: true }
+    ],
+    options: {
+      stringify: function stringify(v){
+        if (v === true) return 'Yes'
+        if (v === false) return 'No'
+        return String(v)
+      }
+    },
+    expected: [
+      '| Name  | Age   | Is cool |',
+      '| ----- | ----- | ------- |',
+      '| Bob   | 21    | No      |',
+      '| Sarah | 22    | Yes     |',
+      '| Lee   | 23    | Yes     |',
+    ].join(os.EOL) + os.EOL
   }
 }

--- a/index.js
+++ b/index.js
@@ -14,7 +14,11 @@ module.exports = (input, options) => {
     )
   }
 
-  options = Object.assign({}, options)
+  options = Object.assign({
+    stringify: v => typeof v === 'undefined' ? '' : String(v)
+  }, options)
+
+  let stringify = options.stringify
 
   let table = ''
 
@@ -36,11 +40,7 @@ module.exports = (input, options) => {
 
   let widths = input.reduce(
     (sizes, item) => keys.map(
-      (key, i) => Math.max(
-        columnWidthMin,
-        typeof item[key] === 'undefined' ? 0 : String(item[key]).length,
-        sizes[i]
-      )
+      (key, i) => Math.max(columnWidthMin, stringify(item[key]).length, sizes[i])
     ),
     titles.map(t => t.length)
   )
@@ -75,10 +75,7 @@ module.exports = (input, options) => {
   // table body
   input.forEach(item => {
     table += row(keys.map((key, i) => {
-      let v = item[key]
-      let s =  typeof v === 'undefined' ? '' : String(v)
-
-      return pad(alignments[i], widths[i], s)
+      return pad(alignments[i], widths[i], stringify(item[key]))
     }))
   })
 

--- a/readme.md
+++ b/readme.md
@@ -79,10 +79,11 @@ tablemark(input, [options = {}])
 - `{Array<Object>} input`: the data to table-ify
 - `{Object} [options = {}]`
 
-| key           | type        | default | description                              |
-| :-----------: | :---------: | :-----: | ---------------------------------------- |
-| `columns`     | `<Array>`   | -       | Array of column descriptors.             |
-| `caseHeaders` | `<Boolean>` | `true`  | Sentence case headers derived from keys. |
+| key           | type         | default | description                              |
+| :-----------: | :----------: | :-----: | ---------------------------------------- |
+| `columns`     | `<Array>`    | -       | Array of column descriptors.             |
+| `caseHeaders` | `<Boolean>`  | `true`  | Sentence case headers derived from keys. |
+| `stringify`   | `<Function>` | -       | Provide a custom "toString" function.    |
 
 The `columns` array can either contain objects, in which case their
 `name` and `align` properties will be used to alter the display of

--- a/test.js
+++ b/test.js
@@ -22,3 +22,8 @@ test('can override sentence casing', t => {
   let result = fn(cases.casing.input, cases.casing.options)
   t.is(result, cases.casing.expected)
 })
+
+test('can use custom stringify function', t => {
+  const result = fn(cases.coerce.input, cases.coerce.options)
+  t.is(result, cases.coerce.expected)
+})


### PR DESCRIPTION
Converting from data to markdown includes things like localizing numbers etc., and probably people should do this conversion prior to passing the data to tablemark.
In that light tablemark should strictly speaking throw on non-strings. This is impractical though, making a case for the current `String(...)` code path.
Due to the above, tablemark can easily expose that as a convenience.

As an example, this is what I prefer:

```js
function(v){
  if (typeof v === 'string') return v
  if (v === true) return 'Y'
  if (v === false) return 'N'
  if (v === undefined || v === null) return ''
  return JSON.stringify(v)
}
```