### PR TITLE
feat: add color option

### DIFF
--- a/fixtures/inputs.js
+++ b/fixtures/inputs.js
@@ -193,5 +193,22 @@ module.exports = {
       '| --------- |',
       '| yes \\| no |'
     ].join(os.EOL) + os.EOL
+  },
+  color: {
+    input: [
+      { name: 'Bob' },
+      { name: 'Sarah' },
+      { name: 'Lee' }
+    ],
+    options: {
+      color: true
+    },
+    expected: [
+      '\x1b[1m| Name  |\x1b[22m',
+      '\x1b[1m\x1b[22m\x1b[90m| ----- |\x1b[39m',
+      '\x1b[90m\x1b[39m| Bob   |',
+      '\x1b[90m| Sarah |\x1b[39m',
+      '\x1b[90m\x1b[39m| Lee   |'
+    ].join(os.EOL) + os.EOL
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "standard": "^10.0.2"
   },
   "dependencies": {
+    "chalk": "^2.1.0",
     "sentence-case": "^2.1.1",
     "split-text-to-chunks": "^1.0.0"
   }

--- a/readme.md
+++ b/readme.md
@@ -57,6 +57,7 @@ tablemark(input[, options = {}])
 | `stringify`    | `<Function>` | -          | Provide a custom "toString" function.          |
 | `wrap.width`   | `<Number>`   | `Infinity` | Wrap texts at this length.                     |
 | `wrap.gutters` | `<Boolean>`  | `false`    | Add sides (`\| <content> \|`) to wrapped rows. |
+| `color`        | `<Boolean>`  | `false`    | Style with ANSI escape codes.                  |
 
 The `columns` array can either contain objects, in which case their
 `name` and `align` properties will be used to alter the display of

--- a/test.js
+++ b/test.js
@@ -52,3 +52,8 @@ test('pipes in content', t => {
   const result = fn(cases.pipes.input, cases.pipes.options)
   t.is(result, cases.pipes.expected)
 })
+
+test('color', t => {
+  const result = fn(cases.color.input, cases.color.options)
+  t.is(result, cases.color.expected)
+})


### PR DESCRIPTION
This is mostly (only?) useful for the CLI which made me consider a different option:
We could allow a custom `line(columns, idx, idxInRow)` function so this could be implemented in the CLI only. That would probably mean `gutters` should be removed though, as it would be a bit redundant and tricky to keep.
Thoughts?